### PR TITLE
Bug: Make `content` field optional in filesystem schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "tps-ai",
-	"version": "1.0.3",
+	"version": "1.0.4",
 	"description": "AI template for Templates",
 	"main": "settings.js",
 	"scripts": {

--- a/settings.js
+++ b/settings.js
@@ -219,7 +219,7 @@ const generateFileContent = async (dest, fileSystem, force = false) => {
 			await fs.mkdir(filePath, { recursive: true });
 		} else {
 			await fs.mkdir(path.dirname(filePath), { recursive: true });
-			await fs.writeFile(filePath, fileOrDir.content, {
+			await fs.writeFile(filePath, fileOrDir.content || '', {
 				flag: force ? 'wx' : 'w',
 			});
 		}

--- a/settings.js
+++ b/settings.js
@@ -19,7 +19,7 @@ const FileSystemObjectSchema = z
 		type: z.enum(['directory', 'file'], {
 			description: 'Type of file system object. either file or directory',
 		}),
-		content: z.string({ description: 'File object contents' }),
+		content: z.string({ description: 'File object contents' }).optional(),
 	})
 	.required({
 		path: true,

--- a/settings.js
+++ b/settings.js
@@ -14,7 +14,7 @@ const FileSystemObjectSchema = z
 	.object({
 		path: z.string({
 			description:
-				"Relative path to the file or directoryn that starts with './'",
+				"Relative path to the file or directory that starts with './'",
 		}),
 		type: z.enum(['directory', 'file'], {
 			description: 'Type of file system object. either file or directory',


### PR DESCRIPTION
## Description

Fix error happening from directories that dont have a content field. This should be optional but for some reason its not at the moment